### PR TITLE
Add Language & Translation category

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 - [By Google](#by-google)
 - [Developer Tools](#developer-tools)
 - [Fun](#fun)
+- [Language & Translation](#language--translation)
 - [News & Weather](#news--weather)
 - [Photos](#photos)
 - [Productivity](#productivity)
@@ -62,6 +63,12 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 
 * [ImprovedTube](https://chrome.google.com/webstore/detail/improvedtube-youtube-exte/bnomihfieiccainjcjblhegjgglakjdd) - Improves YouTube's functions and site with Limited Permissions. Auto HD, Resize, Annotations, Playback Speed and more.
 * [Motivation](https://chrome.google.com/webstore/detail/motivation/ofdgfpchbidcgncgfpdlpclnpaemakoj) - Replaces new tab screen with a real-time counter showing your current age.
+
+## Language & Translation
+*Learn languages and translate content while browsing*
+
+* [Mirlo](https://github.com/BoxcarsAI/mirlo) - Learn a language while you browse — replaces words on pages with the language you're learning. On-device translation via Chrome's Translator API, no tracking.
+* [Read Frog](https://github.com/mengxi-ream/read-frog) - Open-source AI-powered language learning with bilingual translation, article analysis, and vocabulary tools. Supports 80+ languages.
 
 ## News & Weather
 *Keep on track with your environment*


### PR DESCRIPTION
There's no category for language learning or translation extensions. Proposing a new one with two open-source entries:

- **Mirlo** — word-level translation using Chrome's on-device Translator API. I built this one.
- **Read Frog** — AI-powered bilingual translation with article analysis and vocabulary tools.

Different approaches to the same problem — on-device vs. cloud AI, word replacement vs. full-page bilingual. Happy to adjust placement if you'd prefer these under an existing category.