### PR TITLE
Add Related Repos extension to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [SpanTree](https://chrome.google.com/webstore/detail/spantree-gitlab-tree/gcjikeldobhnaglcoaejmdlmbienoocg) - Navigate through GitLab repositories easily.
 * [OpenGraphs](https://www.opengraphs.com/tools/browser-extension) - Open Graph debugger and social share previews, without leaving your site.
 * [vnsh](https://github.com/raullenchai/vnsh) - Encrypted, ephemeral sharing for AI coding assistants. Zero-knowledge AES-256-CBC encryption, auto-expires in 24h.
+* [Related Repos](https://chromewebstore.google.com/detail/related-repos/hjjchbgenhmnndipngamcilolaahgngc) - Quickly view related open source repositories while browsing on GitHub. Results updated daily.
 
 ## Fun
 *Some awesome apps to pass time*


### PR DESCRIPTION
[Related Repos](https://relatedrepos.com/) helps developers to discover open source projects that are related to each other. This can be useful to find alternative or complementary packages when building a full application. Or you can simply surf around in different neighborhoods to find new ideas that you might not have been aware of.

Data and results are updated daily so you can keep coming back to discover fresh repositories. Results can be thought of as "users who expressed interest in this repository also expressed interest in these other repositories".