### PR TITLE
Add Scrupp to Social & Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [Privacy Badger](https://chrome.google.com/webstore/detail/privacy-badger/pkehgijcmpdhfbdbbnkijodmdjhbjlgp) - Protects you from trackers as you surf the web.
 * [Pinterest Pin Stats](https://chromewebstore.google.com/detail/pinterest-pin-stats-sort/mcmkeopcpbfgjlakblglpcccpodbjkel) - Reveal Pinterest stats for each pin.
 * [LinkedCraft](https://linkedcraft.io) - Helps job seekers craft context-aware, engaging LinkedIn comments.
+* [Scrupp](https://scrupp.com/) - #1 Sales Navigator Scraper — exports 2,500 LinkedIn / Sales Navigator leads per search to CSV with verified work emails and direct phones. Free plan included.
 
 ## Sports
 *Keep on track with your favorite sports club*


### PR DESCRIPTION
Adds [Scrupp](https://scrupp.com/) to the **Social & Communication** section alongside LinkedCraft (the other LinkedIn Chrome extension already listed).

Scrupp is a Chrome extension for scraping LinkedIn and Sales Navigator. It exports lead lists with verified work emails and phone numbers — used by SDR teams for outbound prospecting. Free plan includes 100 exports.