### PR TITLE
Add Vidora to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [Ublock Origin](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm) - Efficient blocker, which is easy on CPU and memory.
 * [Umatrix](https://chrome.google.com/webstore/detail/umatrix/ogfcmafjalglgifnmanfmnieipoejdcf) - Point & click to forbid/allow any class of requests made by your browser and use it to block scripts, iframes, ads, facebook, etc.
 * [Video Blocker](https://chrome.google.com/webstore/detail/video-blocker/jknkjnpcbbgcbdbaampbjlhkcghmgfhk) - Hide annoying videos on YouTube from any channel you want.
+* [Vidora](https://chromewebstore.google.com/detail/vidora-pro-video-download/pjnnoldljndmfifpnfmbpbehklaaboje) - Download HLS, DASH and AES-128 encrypted video streams. Vimeo and Bunny CDN supported out of the box. Local processing only, no server upload. Free tier available.
 * [Vimium](https://github.com/philc/vimium) - Provides keyboard-based navigation and control of the web in the spirit of the Vim editor.
 * [Waka Time](https://chrome.google.com/webstore/detail/wakatime/jnbbnacmeggbgdjgaoojpmhdlkkpblgi) - Track your time on chrome automatically.
 * [Word Counter Plus](https://chromewebstore.google.com/detail/word-counter-plus/ockonfdfcanonnajjchhapbiahlhjeej) - A simple and accurate word counter.


### PR DESCRIPTION
### Add Vidora - HLS/DASH/AES-128 video downloader

Adds Vidora to the Productivity section, alphabetically between Video Blocker and Vimium.

**What it is**: a Chrome MV3 extension for downloading video streams from any website.

**Key capabilities**:
- HLS (.m3u8) streams including AES-128 encrypted ones (in-browser decryption)
- DASH (.mpd) manifest support
- External audio rendition handling (Apple-style HLS with separate AAC)
- Native support for Vimeo and Bunny CDN
- All processing is local, no data sent to external servers

**Details**:
- Site: https://getvidora.com
- Chrome Web Store: https://chromewebstore.google.com/detail/vidora-pro-video-download/pjnnoldljndmfifpnfmbpbehklaaboje
- License: freemium (free tier available, $9.99 lifetime)

No existing entry in the Productivity section covers the same scope (AES-128 + DASH + external audio rendition combined). Happy to move to a different section if you prefer.