### PR TITLE
Add Browy to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [OpenGraphs](https://www.opengraphs.com/tools/browser-extension) - Open Graph debugger and social share previews, without leaving your site.
 * [vnsh](https://github.com/raullenchai/vnsh) - Encrypted, ephemeral sharing for AI coding assistants. Zero-knowledge AES-256-CBC encryption, auto-expires in 24h.
 * [Related Repos](https://chromewebstore.google.com/detail/related-repos/hjjchbgenhmnndipngamcilolaahgngc) - Quickly view related open source repositories while browsing on GitHub. Results updated daily.
+* [Browy](https://chromewebstore.google.com/detail/iondecjdokngnlkfpipgolgkfegpmjca) - Open-source AI agent that lives in the side panel and DevTools and drives real browser tabs through chat. Includes a DevTools CLI for power users.
 
 ## Fun
 *Some awesome apps to pass time*


### PR DESCRIPTION
[Browy](https://github.com/BrowyHQ/browy) is an open-source MV3 Chrome extension (Apache-2.0) that lets you drive real browser tabs through chat from two places at once: the side panel for day-to-day work, and a DevTools CLI terminal for power users sitting next to Elements/Network. The agent can call tools like `click`, `type`, `scroll`, `run_js`, `read_dom`, `read_console`, `read_network`, plus opt-in host tools (shell, filesystem, web fetch). The backend is a Node native-messaging host that wraps the GitHub Copilot SDK, so models and quota come from the user's existing GitHub Copilot subscription rather than a new API key.

Docs: https://browyhq.github.io  ·  Repo: https://github.com/BrowyHQ/browy  ·  Chrome Web Store: https://chromewebstore.google.com/detail/iondecjdokngnlkfpipgolgkfegpmjca