### PR TITLE
Add Good Friction for LinkedIn to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [Zenith - Upgrade for YouTube](https://chromewebstore.google.com/detail/zenith-upgrade-for-youtub/ijemkepfnohkofhhcgcnlgkimjonogii) - The ultimate YouTube enhancer. Fixes UI annoyances, unlocks speed limits, and adds 50+ productivity tools.
 * [ZeroTrust](https://github.com/sattyamjjain/zerotrust) - AI-powered website security scanner that runs entirely on-device. Trust scores, phishing detection, SSL checks, and cookie compliance with zero data transmission.
 * [Agentic Workflow (AWFlow)](https://awflow.io) - AI-powered browser extension to automate web tasks, extract data, and run workflows directly in your browser.
+* [Good Friction for LinkedIn](https://github.com/tabrez-syed/goodfriction-linkedin-extension) - Returns the moment of choice to the LinkedIn feed — a session timer and pagination break ask if you want to keep going; a nudge, not a blocker.
 
 ## Search Tools
 *You search for something? Looking here for your tools*


### PR DESCRIPTION
Adding Good Friction for LinkedIn under Productivity — an open-source Chrome extension that adds a session timer and an end-of-feed pause to LinkedIn. A nudge, not a blocker.

I built this one. Thanks for maintaining the list — Mirlo (which you merged in April) has been a steady source of traffic since.