### PR TITLE
Add SubTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 
 * [Raise](https://chrome.google.com/webstore/detail/raisecom-extension/kknoembcnnnhefehcmegppchcmggaafo) - Save money shopping online with discounted gift cards
 * [Subwatch](https://subwatch.co) - Turn subscription chaos into financial harmony.
+* [SubTrack](https://chromewebstore.google.com/detail/subtrack/ggbofficgphbglidcnfkmekiknmbajbc) - Tracks your subscriptions and reminds you before each renewal. Local-first, no account or bank linking.
 
 ## Social & Communication
 *Facebook, Twitter, Google+, Pinterest and so on..*


### PR DESCRIPTION
Adds SubTrack — a local-first Chrome extension that tracks subscriptions and sends a reminder before each renewal. No account, no bank linking; data stays in the browser. Free for 5 subs, one-time paid tier for unlimited.