### PR TITLE
Add Stowtab to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [Session Buddy](https://chrome.google.com/webstore/detail/session-buddy/edacconmaakjimmfgnblocblbcdcpbko) - Manage Browser Tabs and Bookmarks with Ease.
 * [Session Manager](https://chrome.google.com/webstore/detail/session-manager/mghenlmbmjcpehccoangkdpagbcbkdpc) - Quickly and easily save, update, remove, and restore sets of tabs.
 * [Sprucemarks](https://chrome.google.com/webstore/detail/sprucemarks/fakeocdnmmmnokabaiflppclocckihoj) - Automatically sort bookmarks.
+* [Stowtab](https://github.com/gilleswainrib-ext-boop/stowtab) - Local-first tab manager: group by domain, dedupe, native suspend, sessions, and fuzzy search. 3 permissions, no host access, no network calls. MV3, MIT.
 * [SuperSorter](https://chrome.google.com/webstore/detail/supersorter/hjebfgojnlefhdgmomncgjglmdckngij) - Sort bookmarks recursively, delete duplicates, merge folders, sort automatically, etc.
 * [SuperchargePerformance](https://chrome.google.com/webstore/detail/pafkkbjmpnfkdkkhldbbnggnmpbbhkmf) - Suspends inactive tabs using chrome.tabs.discard() to reduce RAM usage. Configurable per-domain whitelist. MV3.
 * [SuperchargeNavigation](https://chrome.google.com/webstore/detail/mpkbppjbchjdohbjgeoamdehklmapgnl) - Workspace-based tab organizer with an Alt+K command bar, Shift+Click peek tabs, and opt-in cross-device sync via chrome.storage.sync. MV3.


### PR DESCRIPTION
Adds **Stowtab** to the Productivity list — a fitting modern, trust-first answer to the (struck-out) Great Suspender entry already in this section.

**Stowtab** is a local-first, open-source (MIT) Chrome tab manager:
- Group tabs by domain, dedupe, native suspend (`chrome.tabs.discard`), save/restore sessions, fuzzy search.
- **3 permissions** (`tabs`, `tabGroups`, `storage`), **zero host permissions**, **zero network calls** — it never phones home.
- Manifest V3. Source-available and loadable from source today: https://github.com/gilleswainrib-ext-boop/stowtab

Note: the Chrome Web Store listing is currently pending review, so the entry links to the GitHub source (consistent with other source-linked entries here like Vimium). Happy to switch it to a Web Store URL once the listing is live, or to adjust the wording/placement however you prefer. Thanks for maintaining this list!