### PR TITLE
Add PR Radar to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [OpenGraphs](https://www.opengraphs.com/tools/browser-extension) - Open Graph debugger and social share previews, without leaving your site.
 * [vnsh](https://github.com/raullenchai/vnsh) - Encrypted, ephemeral sharing for AI coding assistants. Zero-knowledge AES-256-CBC encryption, auto-expires in 24h.
 * [Related Repos](https://chromewebstore.google.com/detail/related-repos/hjjchbgenhmnndipngamcilolaahgngc) - Quickly view related open source repositories while browsing on GitHub. Results updated daily.
+* [PR Radar](https://chromewebstore.google.com/detail/hkombgibegjffiadmekpiabdakkoidmh) - Unified pull request dashboard for GitHub, GitLab, and Bitbucket — CI status, unresolved comments, review state, and notifications, without keeping a tab open.
 
 ## Fun
 *Some awesome apps to pass time*


### PR DESCRIPTION
Adds **PR Radar** to the *Developer Tools* section.

PR Radar is a unified pull request dashboard for **GitHub, GitLab, and Bitbucket** — CI status, unresolved comments, review state, and notifications, without keeping a tab open. Free, no backend (uses personal access tokens).

- Chrome Web Store: https://chromewebstore.google.com/detail/hkombgibegjffiadmekpiabdakkoidmh
- Source: https://github.com/deployhq/pr-radar