### PR TITLE
Add Full Page Screenshot & Screen Recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 
 * [HEIC to PNG Converter](https://chromewebstore.google.com/detail/hlkifcnbooeflbhjbghkgbmjpalnfpia) - Convert HEIC images to JPG/PNG directly in browser. No uploads.
 * [Imagus](https://chrome.google.com/webstore/detail/imagus/immpkjjlgappgfkkfieppnmlhakdmaab) - Enlarge thumbnails, and show images/videos from links with a mouse hover.
+* [Full Page Screenshot & Screen Recorder](https://chromewebstore.google.com/detail/full-page-screenshot-scre/gebkchfkcnjdflkfdimabihllibgcdhp) - Full-page screenshots and screen recording with annotation, webcam, and GIF/MP4 export. No watermark.
 
 ## Productivity
 *Apps to improve your productivity during your day*


### PR DESCRIPTION
Adds Full Page Screenshot & Screen Recorder by SuperchargeBrowser — free, no account, no watermark, no limits. Full-page capture + screen/webcam recording with annotation, GIF/MP4 export. Live on the Chrome Web Store and actively maintained (shipped June 2026).