### PR TITLE
Add PrepPush to the list of developer tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [OpenGraphs](https://www.opengraphs.com/tools/browser-extension) - Open Graph debugger and social share previews, without leaving your site.
 * [vnsh](https://github.com/raullenchai/vnsh) - Encrypted, ephemeral sharing for AI coding assistants. Zero-knowledge AES-256-CBC encryption, auto-expires in 24h.
 * [Related Repos](https://chromewebstore.google.com/detail/related-repos/hjjchbgenhmnndipngamcilolaahgngc) - Quickly view related open source repositories while browsing on GitHub. Results updated daily.
+* [PrepPush](https://chromewebstore.google.com/detail/lkbbmepdmkokiapildnhkimcgnofokdd) - Auto-documents accepted HackerRank solutions to your GitHub repository with AI complexity notes.
 
 ## Fun
 *Some awesome apps to pass time*


### PR DESCRIPTION
PrepPush is a Chrome extension (MV3) that automatically documents accepted HackerRank submissions into the user's own GitHub repository, organized by language and difficulty, with optional Gemini-generated complexity notes. Published on the Chrome Web Store with 50+ users. Source GitHub repository: https://github.com/tridibbanik17/PrepPush