### PR TITLE
Add Chat Organizer to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 
 * [TypoGuard](https://https://chromewebstore.google.com/detail/typoguard-ai-spell-check/khbenciagmckicfldgibdkmklidnmpck) - AI-powered real-time spell check correction and grammar assistant for Google Chrome.
 * [AutoPagerize](https://chrome.google.com/webstore/detail/autopagerize/igiofjhpmpihnifddepnpngfjhkfenbp) - Auto loading paginated web pages.
+* [Chat Organizer](https://chromewebstore.google.com/detail/bipbaacophbcpboieghjoigjlbemchcm) - Auto-sorts your Claude.ai and ChatGPT chats into projects in one click, using keyword matching and AI. Free, no API key or account needed.
 * [CVim](https://chrome.google.com/webstore/detail/cvim/ihlenndgcmojhcghmfjfneahoeklbjjh) - Adding Vim-like bindings to Google Chrome.
 * [Daily](https://chrome.google.com/webstore/detail/daily-20-source-for-busy/jlmpjdjjbgclbocgajdjefcidcncaied) - Replaces your new tab with curated latest dev articles.
 * [Decentraleyes](https://chrome.google.com/webstore/detail/decentraleyes/ldpochfccmkkmhdbclfhpagapcfdljkj) - Protects you against tracking through "free", centralized, content delivery.


### PR DESCRIPTION
Chat Organizer is a free Chrome extension that auto-sorts Claude.ai and ChatGPT chats into projects in one click (keyword matching plus AI for ambiguous titles, full preview before anything moves). No API key or account needed.

- Store: https://chromewebstore.google.com/detail/bipbaacophbcpboieghjoigjlbemchcm
- Site: https://chat-organizer.com

One entry added to the Productivity section, alphabetically placed, following the format guidelines.