### PR TITLE
Add Gmailytics to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [Evernote Web Clipper](https://evernote.com/intl/de/webclipper/) - The easiest way to save, mark up and share anything you see online.
 * [Fauxbar](https://chrome.google.com/webstore/detail/fauxbar/hibkhcnpkakjniplpfblaoikiggkopka) - An alternative to Chrome's Omnibox.
 * [Ghostery](https://chrome.google.com/webstore/detail/ghostery/mlomiejdfkolichcflejclcbmpeaniij) - Protect your privacy by seeing who's tracking your web browsing with Ghostery.
+* [Gmailytics](https://chromewebstore.google.com/detail/gmailytics/nmmkncnnggchmnoinmpoockpdpboonkj) - See which senders fill your inbox, then batch trash or archive them and unsubscribe from newsletters.
 * [Gmail Labels as Tabs](https://tuladhar.github.io/gmail-labels-as-tabs/) - Organize your Gmail labels as tabs.
 * [gTabs](https://chromewebstore.google.com/detail/gtabs-ai-tab-organizer/hcpbchmdcjbgbmjihnenbfalepcdncnb) - AI-powered tab organizer with smart groups that learn your habits, 8 LLM providers including local Ollama, one-click undo, scheduled re-org, and duplicate finder.
 * [LastPass](https://chrome.google.com/webstore/detail/lastpass-free-password-ma/hdokiejnpimakedhajhdlcegeplioahd) - Saves your passwords and gives you secure access from every computer and mobile device


### PR DESCRIPTION
Adds [Gmailytics](https://gmailytics.com) to the Productivity category.

It shows you which senders are filling your Gmail inbox, then lets you batch trash or archive them and unsubscribe from newsletters in bulk.

- Chrome Web Store listing: https://chromewebstore.google.com/detail/gmailytics/nmmkncnnggchmnoinmpoockpdpboonkj
- Featured badge on the Chrome Web Store; also published on Edge Add-ons and Firefox
- Google CASA Tier 2 verified for the `gmail.modify` scope; no data selling

Entry is placed alphabetically and follows the `[APPLICATION](LINK) - DESCRIPTION.` format from CONTRIBUTING.md.