### PR TITLE
Add Publish to dochost to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [ZeroTrust](https://github.com/sattyamjjain/zerotrust) - AI-powered website security scanner that runs entirely on-device. Trust scores, phishing detection, SSL checks, and cookie compliance with zero data transmission.
 * [Agentic Workflow (AWFlow)](https://awflow.io) - AI-powered browser extension to automate web tasks, extract data, and run workflows directly in your browser.
 * [Good Friction for LinkedIn](https://github.com/tabrez-syed/goodfriction-linkedin-extension) - Returns the moment of choice to the LinkedIn feed — a session timer and pagination break ask if you want to keep going; a nudge, not a blocker.
+* [Publish to dochost](https://chromewebstore.google.com/detail/publish-to-dochost/ihnogobgkjojleeiajngmcdlaccjdmdi) - Turns HTML or Markdown generated in ChatGPT and Claude into a shareable link without leaving the chat.
 
 ## Search Tools
 *You search for something? Looking here for your tools*


### PR DESCRIPTION
Adds [Publish to dochost](https://chromewebstore.google.com/detail/publish-to-dochost/ihnogobgkjojleeiajngmcdlaccjdmdi) to **Productivity**.

When ChatGPT or Claude writes you an HTML page or a Markdown document, it is stuck in the chat as code. The extension adds a publish action in the chat UI that turns it into a shareable link, so you can send the rendered page to someone who is not in the conversation.

Also on the [Edge Add-ons store](https://microsoftedge.microsoft.com/addons/detail/publish-to-dochost/ncfhlfhccnpefemneicedajlcghjonol), if the list ever wants an Edge column.

**Guidelines checklist**
- [x] Searched previous suggestions — no existing dochost entry in this list
- [x] Meaningful pull request description
- [x] Single commit for this one suggestion
- [x] Format `[APPLICATION](LINK) - DESCRIPTION.`
- [x] Description is short and ends with a full stop
- [x] Spelling and grammar checked
- [x] No trailing whitespace, and `npx awesome-lint` reports nothing on the added line

Disclosure: I built this extension.