### PR TITLE
Add Offline Spell Check for Web Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [ZeroTrust](https://github.com/sattyamjjain/zerotrust) - AI-powered website security scanner that runs entirely on-device. Trust scores, phishing detection, SSL checks, and cookie compliance with zero data transmission.
 * [Agentic Workflow (AWFlow)](https://awflow.io) - AI-powered browser extension to automate web tasks, extract data, and run workflows directly in your browser.
 * [Good Friction for LinkedIn](https://github.com/tabrez-syed/goodfriction-linkedin-extension) - Returns the moment of choice to the LinkedIn feed — a session timer and pagination break ask if you want to keep going; a nudge, not a blocker.
+* [Offline Spell Check for Web Pages](https://chromewebstore.google.com/detail/offline-spell-check-for-w/degpnnjbkannnfpcdlppeiheiheoglen) - Finds misspelled words on any page, fully offline, with no access to your browsing data.
 
 ## Search Tools
 *You search for something? Looking here for your tools*


### PR DESCRIPTION
Adds Offline Spell Check for Web Pages to Productivity.

It spell-checks the rendered text of any page — including title, alt text, placeholders and aria-labels — using a dictionary bundled inside the extension. No network requests, no account, and only two permissions (activeTab + scripting), so installing it does not trigger the "Read your data on all websites" warning.

The list already has TypoGuard under Productivity; this one is the opposite approach — offline and click-triggered rather than cloud AI and real-time, and it deliberately does not attempt grammar or real-word confusions.

Measured false-positive rate is 0.05% over ~65k words of technical documentation, with 18/18 recall on non-word errors: https://github.com/sserpolar/offline-spell-check/blob/main/BENCHMARK.md

Guidelines: searched existing entries and open PRs for duplicates, single commit, format matches, description is one sentence ending with a period, no trailing whitespace.