### PR TITLE
Add SiteData extension to Search Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 
 * [Find whatever - regex & auto re-find](https://chromewebstore.google.com/detail/find-whatever-regex-auto/pdpkckoiaiinjlhddhcoknjhdncepnbo) - A regex-powered deep search tool that uncovers every hidden corner of the page and tracks results in real-time as content changes.
 
+- [SiteData](https://chromewebstore.google.com/detail/emeakbgdecgmdjgegnejpppcnkcnoaen) - Analyze any website's traffic, SEO keywords, Google Ads activity, and reverse AdSense connections directly in your browser.
+
 ## Shopping
 *Online shopping can be an addiction*
 


### PR DESCRIPTION
Adds [SiteData](https://sitedata.dev/) — a website traffic / SEO / Google Ads intelligence tool:

- Website traffic estimation and audience signals
- Reverse AdSense lookup (discover sites connected by the same AdSense Publisher ID)
- Google Ads advertiser & keyword lookup
- Domain lookup and Domain Rating (DR)
- Free tier + browser extension (Chrome / Edge)

Happy to adjust the wording or category if something fits better. Thanks for maintaining this list!
