### PR TITLE
Add Not for You to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [ZeroTrust](https://github.com/sattyamjjain/zerotrust) - AI-powered website security scanner that runs entirely on-device. Trust scores, phishing detection, SSL checks, and cookie compliance with zero data transmission.
 * [Agentic Workflow (AWFlow)](https://awflow.io) - AI-powered browser extension to automate web tasks, extract data, and run workflows directly in your browser.
 * [Good Friction for LinkedIn](https://github.com/tabrez-syed/goodfriction-linkedin-extension) - Returns the moment of choice to the LinkedIn feed — a session timer and pagination break ask if you want to keep going; a nudge, not a blocker.
+* [Not for You](https://github.com/preziotte/not-for-you) - Removes the algorithm from every major social media platform. Turns off the recommendation feeds on YouTube, Instagram, TikTok, X, Reddit, LinkedIn, Threads and Facebook, so the platforms stop deciding what you see.
 
 ## Search Tools
 *You search for something? Looking here for your tools*


### PR DESCRIPTION
Not for You is an open-source (MIT) browser extension that removes the algorithm from every major social media platform. It turns off the recommendation feeds on YouTube, Instagram, TikTok, X, Reddit, LinkedIn, Threads and Facebook, so the platforms stop deciding what you see.

- Source: https://github.com/preziotte/not-for-you
- Chrome Web Store: https://chromewebstore.google.com/detail/not-for-you/pakdneaipkfgaahgbafblmdebfoadjca
- Firefox Add-ons: https://addons.mozilla.org/firefox/addon/notforyou/

Disclosure: I am the author.
